### PR TITLE
fix(keycloak): close stream correctly in case of exception

### DIFF
--- a/server-spi-private/src/main/java/org/keycloak/utils/StreamsUtil.java
+++ b/server-spi-private/src/main/java/org/keycloak/utils/StreamsUtil.java
@@ -51,6 +51,7 @@ public class StreamsUtil {
         if (iterator.hasNext()) {
             return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, 0), false);
         } else {
+            stream.close();
             throw ex;
         }
     }


### PR DESCRIPTION
Fixes the warning "Datasource 'default': JDBC resources leaked".

The problem and the corresponding fix are described in [a comment in MD-6762](https://moneymeets.atlassian.net/browse/MD-6762?focusedCommentId=116022).