### PR TITLE
ci(actions): create amd64 and arm build for Keycloak

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -31,21 +31,26 @@ jobs:
         id: store-keycloak
         uses: actions/upload-artifact@v4
         with:
-          name: keycloak-distribution
+          name: keycloak-distribution-${{ github.sha }}
           retention-days: 1
           path: quarkus/dist/target/keycloak*.tar.gz
 
   image-build:
     runs-on: ubuntu-latest
-    needs: [maven-build]
+    needs:
+      - maven-build
+
+    env:
+      DOCKER_WORKING_DIR: ${{ github.workspace }}/quarkus/container
+
     steps:
       - uses: actions/checkout@v3
 
       - name: Download Keycloak distribution
         uses: actions/download-artifact@v4
         with:
-          name: keycloak-distribution
-          path: quarkus/container
+          name: keycloak-distribution-${{ github.sha }}
+          path: ${{ env.DOCKER_WORKING_DIR }}
 
       - uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Upload Keycloak artifact
         id: store-keycloak
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: keycloak-distribution
           retention-days: 1
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download Keycloak distribution
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: keycloak-distribution
           path: quarkus/container
@@ -54,7 +54,7 @@ jobs:
           aws-region: ${{ vars.ECR_PUBLIC_REGION }}
 
       - id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
         with:
           registry-type: public
 

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -63,7 +63,12 @@ jobs:
         with:
           registry-type: public
 
-      - name: Build and upload image
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/setup-qemu-action@v3
+
+      - name: Set variables
+        id: set-variables
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
@@ -76,7 +81,14 @@ jobs:
             export IMAGE_TAG=$KEYCLOAK_REPOSITORY:$(echo ${GITHUB_REF_NAME} | awk '{print tolower($0)}' | sed -e 's|/|-|')
           fi
 
-          cd quarkus/container
-          docker build --build-arg KEYCLOAK_DIST=$(ls keycloak-*.tar.gz) . -t ${IMAGE_TAG}
+          echo "image-url-with-tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
 
-          docker push ${IMAGE_TAG}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        env:
+          IMAGE_URL_WITH_TAG: ${{ steps.set-variables.outputs.image-url-with-tag }}
+        with:
+          context: ${{ env.DOCKER_WORKING_DIR }}
+          push: true
+          tags: ${{ env.IMAGE_URL_WITH_TAG }}
+          platforms: linux/amd64,linux/arm64

--- a/quarkus/container/Dockerfile
+++ b/quarkus/container/Dockerfile
@@ -1,17 +1,15 @@
 FROM registry.access.redhat.com/ubi8-minimal AS build-env
 
 ENV KEYCLOAK_VERSION 20.0.5
-ARG KEYCLOAK_DIST=https://github.com/keycloak/keycloak/releases/download/$KEYCLOAK_VERSION/keycloak-$KEYCLOAK_VERSION.tar.gz
+ARG KEYCLOAK_DIST=keycloak-$KEYCLOAK_VERSION.tar.gz
 
 RUN microdnf install -y tar gzip
 
-ADD $KEYCLOAK_DIST /tmp/keycloak/
+COPY $KEYCLOAK_DIST /tmp/keycloak/
 
 # The next step makes it uniform for local development and upstream built.
 # If it is a local tar archive then it is unpacked, if from remote is just downloaded.
-RUN (cd /tmp/keycloak && \
-    tar -xvf /tmp/keycloak/keycloak-*.tar.gz && \
-    rm /tmp/keycloak/keycloak-*.tar.gz) || true
+RUN cd /tmp/keycloak && tar -xvf $KEYCLOAK_DIST && rm $KEYCLOAK_DIST
 
 RUN mv /tmp/keycloak/keycloak-* /opt/keycloak && mkdir -p /opt/keycloak/data
 


### PR DESCRIPTION
As discussed we need the base image for `arm` as well. Both will be pushed to AWS ECR and used as our base image in `keycloak-docker`.