### PR TITLE
feat(email-validation): change email validation to be rfc2822 compliant

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -414,6 +414,11 @@
                 <version>${jakarta.mail.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.github.bbottema</groupId>
+                <artifactId>emailaddress-rfc2822</artifactId>
+                <version>2.3.1</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jboss.spec.javax.transaction</groupId>
                 <artifactId>jboss-transaction-api_1.3_spec</artifactId>
                 <version>${jboss-transaction-api_1.3_spec}</version>

--- a/server-spi-private/pom.xml
+++ b/server-spi-private/pom.xml
@@ -80,6 +80,11 @@
             <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.bbottema</groupId>
+            <artifactId>emailaddress-rfc2822</artifactId>
+            <version>2.3.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/server-spi-private/src/main/java/org/keycloak/validate/validators/EmailValidator.java
+++ b/server-spi-private/src/main/java/org/keycloak/validate/validators/EmailValidator.java
@@ -19,7 +19,6 @@ package org.keycloak.validate.validators;
 import java.util.Collections;
 import java.util.List;
 
-
 import org.keycloak.provider.ConfiguredProvider;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.validate.AbstractStringValidator;

--- a/server-spi-private/src/main/java/org/keycloak/validate/validators/EmailValidator.java
+++ b/server-spi-private/src/main/java/org/keycloak/validate/validators/EmailValidator.java
@@ -18,7 +18,7 @@ package org.keycloak.validate.validators;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.regex.Pattern;
+
 
 import org.keycloak.provider.ConfiguredProvider;
 import org.keycloak.provider.ProviderConfigProperty;
@@ -26,6 +26,8 @@ import org.keycloak.validate.AbstractStringValidator;
 import org.keycloak.validate.ValidationContext;
 import org.keycloak.validate.ValidationError;
 import org.keycloak.validate.ValidatorConfig;
+
+import org.hazlewood.connor.bottema.emailaddress.EmailAddressValidator;
 
 /**
  * Email format validation - accepts plain string and collection of strings, for basic behavior like null/blank values
@@ -39,9 +41,6 @@ public class EmailValidator extends AbstractStringValidator implements Configure
 
     public static final String MESSAGE_INVALID_EMAIL = "error-invalid-email";
 
-    // Actually allow same emails like angular. See ValidationTest.testEmailValidation()
-    private static final Pattern EMAIL_PATTERN = Pattern.compile("[a-zA-Z0-9!#$%&'*+/=?^_`{|}~.-]+@[a-zA-Z0-9-]+(\\.[a-zA-Z0-9-]+)*");
-
     @Override
     public String getId() {
         return ID;
@@ -49,7 +48,7 @@ public class EmailValidator extends AbstractStringValidator implements Configure
 
     @Override
     protected void doValidate(String value, String inputHint, ValidationContext context, ValidatorConfig config) {
-        if (!EMAIL_PATTERN.matcher(value).matches()) {
+        if (!EmailAddressValidator.isValidStrict(value)) {
             context.addError(new ValidationError(ID, inputHint, MESSAGE_INVALID_EMAIL, value));
         }
     }

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -266,7 +266,6 @@
 
                         <!-- Replace the dependencies that aren't in Maven Central -->
                         <dependencies>
-
                             <dependency>
                                 <groupId>ca.szc.thirdparty.nl.jworks.markdown_to_asciidoc</groupId>
                                 <artifactId>markdown_to_asciidoc</artifactId>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -266,6 +266,7 @@
 
                         <!-- Replace the dependencies that aren't in Maven Central -->
                         <dependencies>
+
                             <dependency>
                                 <groupId>ca.szc.thirdparty.nl.jworks.markdown_to_asciidoc</groupId>
                                 <artifactId>markdown_to_asciidoc</artifactId>
@@ -283,6 +284,11 @@
                                         <artifactId>markdown_to_asciidoc</artifactId>
                                     </exclusion>
                                 </exclusions>
+                            </dependency>
+                            <dependency>
+                                <groupId>com.github.bbottema</groupId>
+                                <artifactId>emailaddress-rfc2822</artifactId>
+                                <version>2.3.1</version>
                             </dependency>
                         </dependencies>
 

--- a/services/src/main/java/org/keycloak/services/validation/Validation.java
+++ b/services/src/main/java/org/keycloak/services/validation/Validation.java
@@ -17,6 +17,7 @@
 
 package org.keycloak.services.validation;
 
+import org.hazlewood.connor.bottema.emailaddress.EmailAddressValidator;
 import org.keycloak.models.utils.FormMessage;
 import org.keycloak.userprofile.ValidationException;
 
@@ -34,7 +35,6 @@ public class Validation {
     public static final String FIELD_OTP_LABEL = "userLabel";
 
     // Actually allow same emails like angular. See ValidationTest.testEmailValidation()
-    private static final Pattern EMAIL_PATTERN = Pattern.compile("[a-zA-Z0-9!#$%&'*+/=?^_`{|}~.-]+@[a-zA-Z0-9-]+(\\.[a-zA-Z0-9-]+)*");
     private static final Pattern USERNAME_PATTERN = Pattern.compile("^[\\p{IsLatin}|\\p{IsCommon}]+$");
 
     private static void addError(List<FormMessage> errors, String field, String message, Object... parameters){
@@ -62,7 +62,7 @@ public class Validation {
     }
 
     public static boolean isEmailValid(String email) {
-        return EMAIL_PATTERN.matcher(email).matches();
+        return EmailAddressValidator.isValidStrict(email);
     }
 
     public static boolean isUsernameValid(String username) {


### PR DESCRIPTION
<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->

This PR is made to make email validation on keycloak side RFC compliant, to avoid errors while sending emails.
